### PR TITLE
Add the ability to set the expected true/false

### DIFF
--- a/lib/validation.ex
+++ b/lib/validation.ex
@@ -7,19 +7,27 @@ defmodule SimplyValidate.Validation do
     defexception [:message]
   end
 
-  def validate(data, validators) when is_list(validators) do
-    Enum.reduce(validators, %__MODULE__{data: data}, fn validator, acc ->
-      check(acc, validator)
-    end)
+  def validate(data, validators, default_value \\ true)
+
+  def validate(data, validators, default_value) when is_list(validators) do
+    Enum.reduce(
+      validators,
+      %__MODULE__{data: data},
+      fn
+        {rule, error_msg}, acc -> check(acc, rule, error_msg, default_value)
+        {rule, error_msg, expected_value}, acc -> check(acc, rule, error_msg, expected_value)
+      end
+    )
     |> get_errors()
   end
 
-  def validate(data, validator), do: validate(data, List.wrap(validator))
+  def validate(data, validator, default_value), do: validate(data, List.wrap(validator), default_value)
 
-  defp check(validation, {rule, error_msg}) do
+  defp check(validation, rule, error_msg, ev) do
     case rule.(validation.data) do
-      true -> validation
-      false -> add_error(validation, error_msg)
+      ^ev -> validation
+      v when v != ev and is_boolean(v) -> add_error(validation, error_msg)
+
       bad_return -> raise Validation.Error, message: "validator functions must return true or false, got(#{inspect(bad_return)})"
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SimplyValidate.MixProject do
   def project do
     [
       app: :simply_validate,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/validation_test.exs
+++ b/test/validation_test.exs
@@ -26,4 +26,55 @@ defmodule SimplyValidate.ValidationTest do
       end
     end
   end
+
+  describe "validate/3" do
+    test "returns correct error when a validator does not return default value" do
+      expected_error = "don't let your dreams be dreams"
+
+      errors = Validation.validate(%{a: 5}, [{fn x -> Map.get(x, :a) != nil end, expected_error}], false)
+
+      assert Enum.member?(errors, expected_error)
+    end
+
+    test "returns no error when a validator returns default value" do
+      unexpected_error = "don't let your dreams be dreams"
+
+      errors = Validation.validate(%{}, [{fn x -> Map.get(x, :a) != nil end, unexpected_error}], false)
+
+      refute Enum.member?(errors, unexpected_error)
+    end
+
+    test "validator expected_value overrides default_value (invalid)" do
+      expected_error = "don't let your dreams be dreams"
+
+      errors = Validation.validate(%{}, [{fn x -> Map.get(x, :a) != nil end, expected_error, true}], false)
+
+      assert Enum.member?(errors, expected_error)
+    end
+
+    test "validator expected_value overrides default_value (valid)" do
+      unexpected_error = "don't let your dreams be dreams"
+
+      errors = Validation.validate(%{a: 5}, [{fn x -> Map.get(x, :a) != nil end, unexpected_error, true}], false)
+
+      refute Enum.member?(errors, unexpected_error)
+    end
+
+    test "default_value and validator expected value both work" do
+      true_error = "don't let your dreams be dreams"
+      false_error = "just do it"
+
+      errors = Validation.validate(
+        %{a: 5},
+        [
+          {&Map.has_key?(&1, :b), false_error},
+          {&Map.has_key?(&1, :a), true_error, true}
+        ],
+        false)
+
+      assert errors == []
+      refute Enum.member?(errors, true_error)
+      refute Enum.member?(errors, false_error)
+    end
+  end
 end


### PR DESCRIPTION
You can set a default for the whole validate,
and you can set an expected value for each
validator.

This makes it easier to use functions that
already return a boolean in Elixir such as
String.contains?/2. Now you can more easily
validate the presence or absence of something
with that function, for example.

co-authored-by: Sukaant Chaudhary <sukaant.chaudhary@gmail.com>